### PR TITLE
Bump dependancies

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 23.x]
+        node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"version": "0.1.0",
 	"type": "module",
 	"engines": {
-		"node": ">=22.0.0"
+		"node": ">=24.0.0",
+		"npm": ">=11.6.1"
 	},
 	"prisma": {
 		"seed": "node prisma/seed.js"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"engines": {
 		"node": ">=24.0.0",
-		"npm": ">=11.6.1"
+		"npm": ">=11.6.0"
 	},
 	"prisma": {
 		"seed": "node prisma/seed.js"


### PR DESCRIPTION
Removed deprecated test targets in github CI. Updated Pakcage.json to target latest NPM and Node versions. 